### PR TITLE
Update location for generating Application API docs

### DIFF
--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Generate service provider API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/service-provider.md --renderer=markdown --source-path=crd-temp/service-provider/api/v1beta1
 
-      - name: Generate application service API docs
-        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/application-service.md --renderer=markdown --source-path=crd-temp/application-api/api/v1alpha1
+      - name: Generate application API docs
+        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/application-api.md --renderer=markdown --source-path=crd-temp/application-api/api/v1alpha1
 
       - name: Generate GitOps service API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/gitops.md --renderer=markdown --source-path=crd-temp/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1

--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
       
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout Application API
+      - name: Checkout Application and Environment API
         uses: actions/checkout@v3
         with:
           path: crd-temp/application-api
@@ -54,8 +54,8 @@ jobs:
       - name: Generate service provider API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/service-provider.md --renderer=markdown --source-path=crd-temp/service-provider/api/v1beta1
 
-      - name: Generate application API docs
-        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/application-api.md --renderer=markdown --source-path=crd-temp/application-api/api/v1alpha1
+      - name: Generate application and environment API docs
+        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/application-environment-api.md --renderer=markdown --source-path=crd-temp/application-api/api/v1alpha1
 
       - name: Generate GitOps service API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/gitops.md --renderer=markdown --source-path=crd-temp/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1

--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -20,11 +20,11 @@ jobs:
         uses: actions/checkout@v3
       
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout Application Service
+      - name: Checkout Application API
         uses: actions/checkout@v3
         with:
-          path: crd-temp/application-service
-          repository: redhat-appstudio/application-service
+          path: crd-temp/application-api
+          repository: redhat-appstudio/application-api
 
       - name: Checkout SPI
         uses: actions/checkout@v3
@@ -55,14 +55,11 @@ jobs:
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/service-provider.md --renderer=markdown --source-path=crd-temp/service-provider/api/v1beta1
 
       - name: Generate application service API docs
-        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/application-service.md --renderer=markdown --source-path=crd-temp/application-service/api/v1alpha1
+        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/application-service.md --renderer=markdown --source-path=crd-temp/application-api/api/v1alpha1
 
       - name: Generate GitOps service API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/gitops.md --renderer=markdown --source-path=crd-temp/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1
-      
-      - name: Generate Environment  API docs
-        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/environment.md --renderer=markdown --source-path=crd-temp/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1
-       
+             
       - name: Generate kcp API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/kcp.md --renderer=markdown --source-path=crd-temp/kcp/pkg/apis
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ navigation:
     link: /book/ref/index.html
     sublist: 
     - name: Application Service (HAS)
-      link: /book/ref/application-service.html
+      link: /book/ref/application-api.html
     - name: Service Provider (SPI)
       link: /book/ref/service-provider.html
     - name: GitOps Service

--- a/_config.yml
+++ b/_config.yml
@@ -8,8 +8,8 @@ navigation:
   - name: API References
     link: /book/ref/index.html
     sublist: 
-    - name: Application Service (HAS)
-      link: /book/ref/application-api.html
+    - name: Application and Environment API
+      link: /book/ref/application-environment-api.html
     - name: Service Provider (SPI)
       link: /book/ref/service-provider.html
     - name: GitOps Service

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,5 @@ navigation:
       link: /book/ref/service-provider.html
     - name: GitOps Service
       link: /book/ref/gitops.html
-    - name: Environment API
-      link: /book/ref/environment.html
     - name: Control Plane (KCP)
       link: /book/ref/kcp.html

--- a/book/index.md
+++ b/book/index.md
@@ -56,7 +56,7 @@ Each service is that makes up AppStudio and HACBS are further decomposed on thei
 
 ### Developer Services
 
-- [Application API](../ref/application-api.md)
+- [Application and Environment API](../ref/application-environment-api.md)
 - [Service Provider](../ref/service-provider.md)
 - [GitOps Service](../ref/gitops.md):
 

--- a/book/index.md
+++ b/book/index.md
@@ -56,7 +56,7 @@ Each service is that makes up AppStudio and HACBS are further decomposed on thei
 
 ### Developer Services
 
-- [Application Service](../ref/application-service.md)
+- [Application API](../ref/application-api.md)
 - [Service Provider](../ref/service-provider.md)
 - [GitOps Service](../ref/gitops.md):
 

--- a/ref/index.md
+++ b/ref/index.md
@@ -2,7 +2,7 @@
 
 ## AppStudio
 
-- [Application Service](application-service.md): Hybrid Application Service (HAS) provides an abstract way to define applications within the cloud. Includes shared APIs for defining and managing environments.
+- [Application API](application-api.md): Hybrid Application Service (HAS) provides an abstract way to define applications within the cloud. Also includes shared APIs for defining and managing environments.
 - [Service Provider](service-provider.md): Responsible for providing a service-provider-neutral way of obtaining authentication tokens so that tools accessing the service provider do not have to deal with the intricacies of getting the access tokens from the different service providers.
 - [GitOps Service](gitops.md): Responsible for synchronizing source K8s resources in a Git repository (as the single of truth), with target OpenShift/K8s cluster(s).
 

--- a/ref/index.md
+++ b/ref/index.md
@@ -2,10 +2,9 @@
 
 ## AppStudio
 
-- [Application Service](application-service.md): Hybrid Application Service (HAS) provides an abstract way to define applications within the cloud.
+- [Application Service](application-service.md): Hybrid Application Service (HAS) provides an abstract way to define applications within the cloud. Includes shared APIs for defining and managing environments.
 - [Service Provider](service-provider.md): Responsible for providing a service-provider-neutral way of obtaining authentication tokens so that tools accessing the service provider do not have to deal with the intricacies of getting the access tokens from the different service providers.
 - [GitOps Service](gitops.md): Responsible for synchronizing source K8s resources in a Git repository (as the single of truth), with target OpenShift/K8s cluster(s).
-- [Environment API](environment.md): Shared APIs for defining and managing environments.
 
 
 ## Control Plane

--- a/ref/index.md
+++ b/ref/index.md
@@ -2,7 +2,7 @@
 
 ## AppStudio
 
-- [Application API](application-api.md): Hybrid Application Service (HAS) provides an abstract way to define applications within the cloud. Also includes shared APIs for defining and managing environments.
+- [Application and Environment API](application-environment-api.md): Hybrid Application Service (HAS) provides an abstract way to define applications within the cloud. Also includes shared APIs for defining and managing environments.
 - [Service Provider](service-provider.md): Responsible for providing a service-provider-neutral way of obtaining authentication tokens so that tools accessing the service provider do not have to deal with the intricacies of getting the access tokens from the different service providers.
 - [GitOps Service](gitops.md): Responsible for synchronizing source K8s resources in a Git repository (as the single of truth), with target OpenShift/K8s cluster(s).
 


### PR DESCRIPTION
This PR updates the API doc generation to use the [application-api repository](https://github.com/redhat-appstudio/application-api.git) for generating the API docs for HAS & Environment APIs. 

I've renamed the generated page to `application-api.md` and updated corresponding descriptions to include references to the Environment API.