### PR TITLE
ADR-0001: Pipeline Service Phase 1

### DIFF
--- a/ADR/adr-0001-pipeline-service-phase-1.md
+++ b/ADR/adr-0001-pipeline-service-phase-1.md
@@ -1,0 +1,44 @@
+# ADR-0001 Pipeline Service Phase 1
+
+Created: 2022-10-13
+Last Updated: 2022-10-13
+
+## Status
+
+Accepted
+
+## Context
+
+App Studio initially ran on a single cluster and provisioned [Tekton](https://tekton.dev) controllers.
+With the migration to [kcp](https://github.com/kcp-dev/kcp), controllers need to either a) be made "kcp aware", or b) run on all workload clusters, targeting the same kcp `APIExport`.
+App Studio could build this on their own, however other services and teams beyond App Studio need the ability to run Tekton pipelines.
+
+Tekton code utilizes libraries that are not simple to refactor and make "kcp aware."
+Furthermore, Tekton is an upstream project with a wide, active community.
+Adding kcp-aware changes would require upstream acceptance, or require us to fork Tekton and apply our "kcp aware" patches.
+
+## Decision
+
+Tekton APIs and services will be provided through a separate, independent service - Pipeline Service.
+App Studio and HACBS will be "customer 0" for Pipeline Service.
+Future managed services which rely on Tekton APIs can bind to the Pipeline Service and start running pipelines right away.
+
+Pipeline Service will deploy and manage Tekton controllers directly on workload clusters.
+kcp syncers will be used to generate APIExports from the workload cluster.
+We will utilize the OpenShift Pipelines Operator to deploy Tekton controllers to the furthest extent possible, whose configuration will be controlled via ArgoCD.
+Otherwise, other Tekton controllers will be deployed with direct manifests.
+
+Arch Diagram: https://miro.com/app/board/uXjVOVEW0IM=/
+
+## Consequences
+
+- Other services use an APIBinding to execute `PipelineRuns` (and access Tekton APIs) in kcp.
+- `TaskRun` objects cannot be synced to KCP.
+  App Studio and HACBS components may only interact with `PipelineRun` objects directly.
+- Workload clusters for Pipeline Service need to be directly managed by the Pipeline Service team.
+  We cannot rely on general "compute as a service" from kcp Control Plane Service (CPS).
+- Pipelines as Code (PaC) needs a separate ingress and service configured on KCP, which forwards traffic to PaC on the workload cluster.
+  - `Ingress` support on kcp comes from an add-on capability - the [kcp Global Load Balancer Controller](https://github.com/kcp-dev/kcp-glbc).
+  - `PipelineRun` objects created by PaC are not visible on kcp.
+  - We are limited to one workload cluster - the gateway cannot load balance traffic across clusters.
+- Tekton Results can only be accessed on workload clusters. It would require additional changes/patches to make it accessible from kcp.

--- a/book/index.md
+++ b/book/index.md
@@ -43,6 +43,7 @@ The diagram below shows the interaction of the AppStudio and HACBS with other sy
 Each service is that makes up AppStudio and HACBS are further decomposed on their own documents.
 
 - [GitOps Service](./gitops-service.md)
+- [Pipeline Service](./pipeline-service.md)
 - [Build Service](./build-service.md)
 - [Workspace and Terminal Service](./workspace-and-terminal-service.md)
 - [Service Provider Integration](./service-provider-integration.md)

--- a/book/pipeline-service.md
+++ b/book/pipeline-service.md
@@ -1,0 +1,29 @@
+# Pipeline Service
+
+Pipeline Service provides Tekton APIs and services to kcp workspaces.
+When a workspace binds to the Pipeline Service APIExport, it has access to the following Tekton APIs:
+
+- `Task`
+- `Pipeline`
+- `PipelineRun`
+- `Repository` (for [Pipelines as Code](https://pipelinesascode.com))
+
+The following features are also provided:
+
+- Signing and attestation of `TaskRuns` with [Tekton Chains](https://tekton.dev/docs/chains/)
+- Archiving of `PipelineRuns` and `TaskRuns` with [Tekton Results](https://tekton.dev/docs/results/)
+- Integrations with GitHub, Gitlab, and Bitbucket with [Pipelines as Code](https://pipelinesascode.com) (PaC).
+
+## Architecture
+
+Tekton controllers are deployed directly on the workload cluster.
+The kcp syncer for the workload cluster is configured to sync `Pipeline`, `Task`, and `PipelineRun` objects.
+When a `PipelineRun` is created on kcp, it is synced to the workload cluster whose controllers then create `TaskRun` objects and resulting `Pods`.
+The Chains and Results controllers then work with the synced `PipelineRun` and generated `TaskRun` objects to perform their respective actions.
+
+Like upstream Tekton, Pipelines as Code (PaC) also runs controllers directly on workload clusters.
+Unlike other Tekton components, PaC also exposes a `Route`/`Ingress` that allows it to receive webhook events from source control repositories.
+To sent traffic from kcp to the workload cluster, Pipeline Service will deploy a "gateway" service that acts as a proxy to PaC on the workload cluster.
+
+Tekton Results will likewise use the gateway to forward requests to its service.
+The apiserver will be patched to translate kcp workspaces/namespaces to the respective synced namespace on the workload cluster.

--- a/ref/index.md
+++ b/ref/index.md
@@ -5,6 +5,7 @@
 - [Application and Environment API](application-environment-api.md): Hybrid Application Service (HAS) provides an abstract way to define applications within the cloud. Also includes shared APIs for defining and managing environments.
 - [Service Provider](service-provider.md): Responsible for providing a service-provider-neutral way of obtaining authentication tokens so that tools accessing the service provider do not have to deal with the intricacies of getting the access tokens from the different service providers.
 - [GitOps Service](gitops.md): Responsible for synchronizing source K8s resources in a Git repository (as the single of truth), with target OpenShift/K8s cluster(s).
+- [Pipeline Service](pipeline-service.md): Responsible for executing Tekton `PipelineRuns` and providing acccess to Tekton services.
 
 
 ## Control Plane


### PR DESCRIPTION
This ADR documents our decision to deploy Tekton controllers directly on workload clusters, a.k.a "Pipeline Service Phase 1." It also documents our rationale for separating Pipeline Service from App Studio and HACBS.

The associated content provides the high level summary and architecture of Pipeline Service under our initial idea for Phase 1 (circa July 2022). This architecture is intentionally obsolete, as some aspects of the design have been rendered obsolete by changes in kcp.