### PR TITLE
Generate an ADR index

### DIFF
--- a/.github/workflows/gen-deploy-site.yml
+++ b/.github/workflows/gen-deploy-site.yml
@@ -24,9 +24,16 @@ jobs:
   generate-api-docs:
     uses: ./.github/workflows/generate-api-docs.yml
     secrets: inherit
+
+  generate-adr-index:
+    uses: ./.github/workflows/generate-adr-index.yml
+    secrets: inherit
+
   # Build job
   build:
-    needs: generate-api-docs
+    needs:
+      - generate-api-docs
+      - generate-adr-index
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,6 +43,11 @@ jobs:
         with:
           name: api-docs
           path: ref/
+      - name: Download generated ADR index
+        uses: actions/download-artifact@v3
+        with:
+          name: adr-index
+          path: ADR/
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Build with Jekyll

--- a/.github/workflows/generate-adr-index.yml
+++ b/.github/workflows/generate-adr-index.yml
@@ -1,0 +1,30 @@
+name: generate-adr-index
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  generate-adr-index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout docs repo
+        uses: actions/checkout@v3
+
+      - name: Generate ADR header
+        run: echo "# Architecture Decision Records (ADRs)" > index.md
+        working-directory: ./ADR
+
+      - name: Generate ADR list
+        run: for adr in *.md; do title=$(head -1 $adr); echo "* [${title:2}](./$adr)" >> index.md; done
+        working-directory: ./ADR
+
+      - name: Delete self-reference to index.md
+        run: sed -i '/index.md/d' index.md
+        working-directory: ./ADR
+
+      - name: Upload generated index
+        uses: actions/upload-artifact@v3
+        with:
+          name: adr-index
+          path: ADR/

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,8 @@ color-scheme: auto
 navigation:
   - name: Technical Overview Document
     link: /book/book/index.html
+  - name: Architecture Decision Records
+    link: /book/ADR/index.html
   - name: API References
     link: /book/ref/index.html
     sublist: 


### PR DESCRIPTION
Similar to the API index - as we add new ADRs, this will update a list of them, linked from the sidebar.