### PR TITLE
Fix link reference to enterprise-contract

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -48,7 +48,7 @@ Each service is that makes up AppStudio and HACBS are further decomposed on thei
 - [Workspace and Terminal Service](./workspace-and-terminal-service.md)
 - [Service Provider Integration](./service-provider-integration.md)
 - [Hybrid Application Service](./hybrid-application-service.md)
-- [Enterprise Contract](./enterprise-contract-service.md)
+- [Enterprise Contract](./enterprise-contract.md)
 - [Java Rebuilds Service](./java-rebuilds-service.md)
 - [Release Service](./release-service.md)
 - Integration Service


### PR DESCRIPTION
This should have been in 2450b5e0179bd2074c14e00e864ae64ae8664be6.