### PR TITLE
adds index.md for diagrams

### DIFF
--- a/diagrams/index.md
+++ b/diagrams/index.md
@@ -1,0 +1,16 @@
+# Diagrams
+
+## System Context
+
+The diagram below shows the interaction of the AppStudio and HACBS with other systems and environments.
+
+![](../diagrams/appstudio-hacbs-l1.drawio.svg)
+
+
+## Application Context
+
+![](../diagrams/appstudio-hacbs-l2.drawio.svg)
+
+## Workspace Layout
+
+![](../diagrams/appstudio-workspace-layout.drawio.svg)


### PR DESCRIPTION
From the main index page on the rendered "Book of App Studio", the link to the Diagrams folder is broken; it seems that it doesn't know what to do with SVGs with no index page. 

https://redhat-appstudio.github.io/book/diagrams/
<img width="652" alt="image" src="https://user-images.githubusercontent.com/1302432/201361977-337b454f-0d91-4952-90b8-a27b6e020d7a.png">
