### PR TITLE
ADR-006 log conventions

### DIFF
--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -28,7 +28,7 @@ We will apply the following labels to App Studio namespaces, to make them easier
 
 ## Decision 2: Log conventions
 
-In our application logs, we will use structured, JSON-formatted audit log messages with key-value pairs as described below.
+In our controller logs, we will use structured, JSON-formatted audit log messages with key-value pairs as described below.
 
 Fluentd and Fluent Bit annotate log messages with the following information automatically: `namespace_name`, `container_name`, `pod_name`, `container_image`, `pod_ip`, `host`, `hostname`, `namespace_labels`, `message`, `level`, `time`, and more. The cluster, node, pod and container names are also part of the log stream name.  For example:
   Under /aws/containerinsights/`Cluster_Name`/application

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -57,7 +57,7 @@ Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. 
 - Workspace and Terminal Service: TBD
 - Service Provider Integration: `SPI`
 - Hybrid Application Service: `HAS`
-- Enterprise Contract: TBD
+- Enterprise Contract: EC
 - Java Rebuilds Service: JAVA
 - Release Service: TBD
 - Integration Service: TBD

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -53,7 +53,7 @@ Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. 
 
 - GitOps Service: `GITOPS`
 - Pipeline Service: PLNSRVCE
-- Build Service: TBD
+- Build Service: BUILD
 - Workspace and Terminal Service: TBD
 - Service Provider Integration: `SPI`
 - Hybrid Application Service: `HAS`

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -15,18 +15,9 @@ Accepted
 
 ## Context
 
-We need naming standards in various contexts, to make App Studio easier to operate and maintain.
+We need log conventions to make App Studio easier to operate and maintain. These will also make it possible for us to create queries that cross components in our logs.
 
-## Decision 1: Namespace labels
-
-We will apply the following labels to App Studio namespaces, to make them easier to find.
-
-- `appstudio.redhat.com/namespacetype: "controller"` for namespaces containing App Studio controllers
-- `appstudio.redhat.com/namespacetype: "user-workspace-data"` for User workspaces where Applications, Components, and so on are defined
-- `appstudio.redhat.com/namespacetype: "user-deployments"` for the namespaces where GitOps deploys applications for users
-- `appstudio.redhat.com/namespacetype: "user-builds"` for the namespaces where the Pipeline Service has PipelineRuns
-
-## Decision 2: Log conventions
+## Decision: Log conventions
 
 In our controller logs, we will use structured, JSON-formatted audit log messages with key-value pairs as described below.
 
@@ -45,22 +36,22 @@ Timestamps will be in UTC/ISO-8601 format.
 
 ### 2. What happened?
 
-Use the key `action` with possible values `ADD, UPDATE, DELETE`.
+Use the key `action` with possible values `VIEW, ADD, UPDATE, DELETE`.
 
 ### 3. Where did it happen?
 
 Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. Here is [sample code](https://github.com/redhat-appstudio/application-service/blob/9f25d1f6832568598c718423b1e2f7d9161ad790/controllers/component_controller.go#L549) from the HAS component.
 
 - GitOps Service: `GITOPS`
-- Pipeline Service: PLNSRVCE
-- Build Service: BUILD
+- Pipeline Service: `PLNSRVCE`
+- Build Service: `BUILD`
 - Workspace and Terminal Service: TBD
 - Service Provider Integration: `SPI`
 - Hybrid Application Service: `HAS`
-- Enterprise Contract: EC
-- Java Rebuilds Service: JAVA
-- Release Service: RELEASE
-- Integration Service: INTEGRATION
+- Enterprise Contract: `EC`
+- Java Rebuilds Service: `JAVA`
+- Release Service: `RELEASE`
+- Integration Service: `INTEGRATION`
 
 ### 4. Who was involved?
 
@@ -74,7 +65,7 @@ Use the key `resource` with the name of the resource being acted upon.
 
 Optionally, use the key `source` to direct developers to the source code where the action occurred. 
 
-### Application audit logs
+### Controller audit logs
 
 For the specific types of audit logs required by SSML.PW.5.1.4 Perform Event Logging, one of the key-value pairs in the log entry should be `audit: true`. This makes it easier to query aggregated logs to find these special log entries.
 

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -4,7 +4,14 @@ Date: 2022-November-11
 
 ## Status
 
-Draft
+Accepted
+
+## Approvers
+
+* Ann Marie Fred
+* Gorkem Ercan
+
+## Reviewers
 
 ## Context
 

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -15,7 +15,7 @@ Accepted
 
 ## Context
 
-We need log conventions to make App Studio easier to operate and maintain. These will also make it possible for us to create queries that cross components in our logs.
+We need log conventions to make our offering easier to operate and maintain. These will also make it possible for us to create queries that cross components in our logs.
 
 ## Decision: Log conventions
 
@@ -40,7 +40,7 @@ Use the key `action` with possible values `VIEW, ADD, UPDATE, DELETE`.
 
 ### 3. Where did it happen?
 
-Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. Here is [sample code](https://github.com/redhat-appstudio/application-service/blob/9f25d1f6832568598c718423b1e2f7d9161ad790/controllers/component_controller.go#L549) from the HAS component.
+Use the key `stonesoup-component` with possible values `HAS, SPI, GITOPS`, etc. Here is [sample code](https://github.com/redhat-appstudio/application-service/blob/9f25d1f6832568598c718423b1e2f7d9161ad790/controllers/component_controller.go#L549) from the HAS component.
 
 - GitOps Service: `GITOPS`
 - Pipeline Service: `PLNSRVCE`

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -1,4 +1,4 @@
-# 1. Record architecture decisions
+# ADR-0006 Log Conventions
 
 Date: 2022-November-11
 

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -37,7 +37,7 @@ Fluentd and Fluent Bit annotate log messages with the following information auto
 
 For more details on Fluentd vs. Fluent Bit logs, see [Set up Fluent Bit as a DaemonSet to send logs to CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs-FluentBit.html).
 
-It is best to avoid using the same key as the log collectors in our application logs, to avoid confusion.
+It is best to avoid using the same key as the log collectors in our controller logs, to avoid confusion.
 
 ### 1. When did it happen? 
 

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -58,7 +58,7 @@ Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. 
 - Service Provider Integration: `SPI`
 - Hybrid Application Service: `HAS`
 - Enterprise Contract: TBD
-- Java Rebuilds Service: TBD
+- Java Rebuilds Service: JAVA
 - Release Service: TBD
 - Integration Service: TBD
 

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -60,7 +60,7 @@ Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. 
 - Enterprise Contract: EC
 - Java Rebuilds Service: JAVA
 - Release Service: TBD
-- Integration Service: TBD
+- Integration Service: INTEGRATION
 
 ### 4. Who was involved?
 

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -59,7 +59,7 @@ Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. 
 - Hybrid Application Service: `HAS`
 - Enterprise Contract: EC
 - Java Rebuilds Service: JAVA
-- Release Service: TBD
+- Release Service: RELEASE
 - Integration Service: INTEGRATION
 
 ### 4. Who was involved?

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -68,7 +68,9 @@ Use the key `namespace` when logging the namespace of the targeted resource that
 
 ### 5. Where it came from? 
 
-Use the key `resource` with possible resource name values determined by the component team.  For example, for HAS this can be `CDQ, Application, Component`, etc. 
+Use the key `kind` with possible resource kind values determined by the component team.  For example, for HAS this can be `CDQ, Application, Component`, etc. 
+
+Use the key `resource` with the name of the resource being acted upon.
 
 Optionally, use the key `source` to direct developers to the source code where the action occurred. 
 

--- a/ADR/adr-0006-names-labels.md
+++ b/ADR/adr-0006-names-labels.md
@@ -52,7 +52,7 @@ Use the key `action` with possible values `ADD, UPDATE, DELETE`.
 Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. Here is [sample code](https://github.com/redhat-appstudio/application-service/blob/9f25d1f6832568598c718423b1e2f7d9161ad790/controllers/component_controller.go#L549) from the HAS component.
 
 - GitOps Service: `GITOPS`
-- Pipeline Service: TBD
+- Pipeline Service: PLNSRVCE
 - Build Service: TBD
 - Workspace and Terminal Service: TBD
 - Service Provider Integration: `SPI`

--- a/ADR/adr-006-names-labels.md
+++ b/ADR/adr-006-names-labels.md
@@ -1,0 +1,76 @@
+# 1. Record architecture decisions
+
+Date: 2022-November-11
+
+## Status
+
+Draft
+
+## Context
+
+We need naming standards in various contexts, to make App Studio easier to operate and maintain.
+
+## Decision 1: Namespace labels
+
+We will apply the following labels to App Studio namespaces, to make them easier to find.
+
+- `appstudio.redhat.com/namespacetype: "controller"` for namespaces containing App Studio controllers
+- `appstudio.redhat.com/namespacetype: "user-workspace-data"` for User workspaces where Applications, Components, and so on are defined
+- `appstudio.redhat.com/namespacetype: "user-deployments"` for the namespaces where GitOps deploys applications for users
+- `appstudio.redhat.com/namespacetype: "user-builds"` for the namespaces where the Pipeline Service has PipelineRuns
+
+## Decision 2: Log conventions
+
+In our application logs, we will use structured, JSON-formatted audit log messages with key-value pairs as described below.
+
+Fluentd and Fluent Bit annotate log messages with the following information automatically: `namespace_name`, `container_name`, `pod_name`, `container_image`, `pod_ip`, `host`, `hostname`, `namespace_labels`, `message`, `level`, `time`, and more. The cluster, node, pod and container names are also part of the log stream name.  For example:
+  Under /aws/containerinsights/`Cluster_Name`/application
+  - Fluent Bit optimized configuration sends logs to `kubernetes-nodeName`-application.var.log.containers.`kubernetes-podName`_`kubernetes-namespace`_`kubernetes-container-name`-`kubernetes-containerID`
+  - Fluentd sends logs to `kubernetes-podName`_`kubernetes-namespace`_`kubernetes-containerName`_`kubernetes-containerID`
+
+For more details on Fluentd vs. Fluent Bit logs, see [Set up Fluent Bit as a DaemonSet to send logs to CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs-FluentBit.html).
+
+It is best to avoid using the same key as the log collectors in our application logs, to avoid confusion.
+
+### 1. When did it happen? 
+
+Timestamps will be in UTC/ISO-8601 format.
+
+### 2. What happened?
+
+Use the key `action` with possible values `ADD, UPDATE, DELETE`.
+
+### 3. Where did it happen?
+
+Use the key `appstudio-component` with possible values `HAS, SPI, GITOPS`, etc. Here is [sample code](https://github.com/redhat-appstudio/application-service/blob/9f25d1f6832568598c718423b1e2f7d9161ad790/controllers/component_controller.go#L549) from the HAS component.
+
+- GitOps Service: `GITOPS`
+- Pipeline Service: TBD
+- Build Service: TBD
+- Workspace and Terminal Service: TBD
+- Service Provider Integration: `SPI`
+- Hybrid Application Service: `HAS`
+- Enterprise Contract: TBD
+- Java Rebuilds Service: TBD
+- Release Service: TBD
+- Integration Service: TBD
+
+### 4. Who was involved?
+
+Use the key `namespace` when logging the namespace of the targeted resource that is being modified.
+
+### 5. Where it came from? 
+
+Use the key `resource` with possible resource name values determined by the component team.  For example, for HAS this can be `CDQ, Application, Component`, etc. 
+
+Optionally, use the key `source` to direct developers to the source code where the action occurred. 
+
+### Application audit logs
+
+For the specific types of audit logs required by SSML.PW.5.1.4 Perform Event Logging, one of the key-value pairs in the log entry should be `audit: true`. This makes it easier to query aggregated logs to find these special log entries.
+
+More details can be found in [SSML-8093](https://issues.redhat.com/browse/SSML-8093), and a good example of a working implementation can be found in the [GitOps code](https://github.com/redhat-appstudio/managed-gitops/blob/c962ae99ec50e273c8cdf90d8f3a07f7a8944dc5/backend-shared/util/log.go#L28) implemented for [this story](https://issues.redhat.com/browse/GITOPSRVCE-186).
+
+## Consequences
+
+TBD


### PR DESCRIPTION
I think it would be easier to keep all of our log conventions in one ADR.
Note that the component teams are not currently following the same conventions, so this will require some work on their part to align to this standard.
I pulled the logging information from this [Slack thread](https://coreos.slack.com/archives/C02CTEB3MMF/p1664550010076759).

Other useful background info:
The requirement we're trying to meet: https://issues.redhat.com/browse/SSML-8093 
GitOps Service implementation example: https://issues.redhat.com/browse/GITOPSRVCE-186 and https://github.com/redhat-appstudio/managed-gitops/blob/main/backend-shared/util/log.go#L28 