### PR TITLE
ADR-0010 Namespace metadata we will need

### DIFF
--- a/ADR/adr-0010-namespace-metadata
+++ b/ADR/adr-0010-namespace-metadata
@@ -15,21 +15,24 @@ Accepted
 
 ## Context
 
-We need metadata on our namespaces to make Stone Soup easier to operate and maintain. Standardizing namespace metadata will make it easier for us to search our logs and metrics across clusters. It will also allow us to enable logging for outgoing network traffic, one of our security requirements.
+We need metadata on our namespaces to make Stonesoup easier to operate and maintain. Standardizing namespace metadata will make it easier for us to search our logs and metrics across clusters. It will also allow us to enable logging for outgoing network traffic, one of our security requirements.
 
 ## Namespace labels
 
-We will apply the following labels to Stone Soup namespaces, to make them easier to find.
+We will apply the following labels to Stonesoup namespaces, to make them easier to identify programmatically:
 
-- `stonesoup.redhat.com/namespacetype: "controller"` for namespaces containing Stone Soup controllers
-- `stonesoup.redhat.com/namespacetype: "user-workspace-data"` for User workspaces where Applications, Components, and so on are defined
+- `stonesoup.redhat.com/namespacetype: "controller"` for namespaces containing controllers developed for Stonesoup. For example, we would annotate the `gitops-service-argocd` namespace but not the `openshift-gitops` namespace.
+- `stonesoup.redhat.com/namespacetype: "user-workspace-data"` for User workspaces where Applications, Components, and so on are stored
 - `stonesoup.redhat.com/namespacetype: "user-deployments"` for the namespaces where GitOps deploys applications for users
-- `stonesoup.redhat.com/namespacetype: "user-builds"` for the namespaces where the Pipeline Service has PipelineRuns
+- `stonesoup.redhat.com/namespacetype: "user-builds"` for the namespaces where the Pipeline Service manages users' PipelineRun resources
+
+The following labels are used for billing and telemetry. Values can be left blank if they are not defined yet:
+
 - `stonesoup.redhat.com/workspace_id: 12345678` a globally unique identifier for the workspace
-- `stonesoup.redhat.com/workspace_name: "test_workspace"` name for the workspace (need not be unique)
+- `stonesoup.redhat.com/workspace_name: "test_workspace"` a name for the workspace (need not be unique)
 - `stonesoup.redhat.com/external_organization: 11868048` the Red Hat orgId
 - `stonesoup.redhat.com/product_variant: "Stonesoup"` identifier for the type of product (allows tracking multiple variants in the same metric)
-- `stonesoup.redhat.com/sku_account_support: "Standard"` Standard, Premium, or Self-Support. Must match the value from the SKU
+- `stonesoup.redhat.com/sku_account_support: "Standard"` Standard, Premium, or Self-Support. Must match the value from the SKU.
 - `stonesoup.redhat.com/sku_env_usage: "Production"` Development/Test, Production, or Disaster Recovery. Must match the value from the SKU
 - `stonesoup.redhat.com/billing_model: "marketplace"` must be set to marketplace to indicate this service instance is billed through marketplace. This allows you to mark some instances as billed via marketplace (and some as not billed through marketplace)
 - `stonesoup.redhat.com/billing_marketplace: "aws"` which marketplace is used for billing
@@ -37,7 +40,7 @@ We will apply the following labels to Stone Soup namespaces, to make them easier
 
 ## Namespace annotations
 
-We will apply the following annotation to Stone Soup namespaces, which will enable OVN network logging to log outgoing network traffic:
+We will apply the following annotation to namespaces installed and maintained by Stonesoup on the clusters that Red Hat manages.  This will enable OVN network logging to log outgoing network traffic:
 
 metadata:
   annotations:
@@ -45,4 +48,4 @@ metadata:
 
 ## Consequences
 
-TBD
+We might have to migrate `stonesoup.redhat.com` to another product name in the future.

--- a/ADR/adr-0010-namespace-metadata
+++ b/ADR/adr-0010-namespace-metadata
@@ -1,0 +1,39 @@
+# 1. Record architecture decisions
+
+Date: 2022-November-11
+
+## Status
+
+Accepted
+
+## Approvers
+
+* Ann Marie Fred
+* Gorkem Ercan
+
+## Reviewers
+
+## Context
+
+We need metadata on our namespaces to make Stone Soup easier to operate and maintain. Standardizing namespace metadata will make it easier for us to search our logs and metrics across clusters. It will also allow us to enable logging for outgoing network traffic, one of our security requirements.
+
+## Namespace labels
+
+We will apply the following labels to Stone Soup namespaces, to make them easier to find.
+
+- `stonesoup.redhat.com/namespacetype: "controller"` for namespaces containing Stone Soup controllers
+- `stonesoup.redhat.com/namespacetype: "user-workspace-data"` for User workspaces where Applications, Components, and so on are defined
+- `stonesoup.redhat.com/namespacetype: "user-deployments"` for the namespaces where GitOps deploys applications for users
+- `stonesoup.redhat.com/namespacetype: "user-builds"` for the namespaces where the Pipeline Service has PipelineRuns
+
+## Namespace annotations
+
+We will apply the following annotation to Stone Soup namespaces, which will enable OVN network logging to log outgoing network traffic:
+
+metadata:
+  annotations:
+    k8s.ovn.org/acl-logging: '{"deny": "info", "allow": "info"}'
+
+## Consequences
+
+TBD

--- a/ADR/adr-0010-namespace-metadata
+++ b/ADR/adr-0010-namespace-metadata
@@ -22,7 +22,7 @@ We need metadata on our namespaces to make Stonesoup easier to operate and maint
 
 ## Namespace labels
 
-We will apply the following labels to Stonesoup namespaces, to make them easier to identify programmatically:
+We will apply the following labels to Stonesoup namespaces, to make them easier to identify programmatically. One namespace can have multiple types/labels:
 
 - `appstudio.redhat.com/namespacetype: "controller"` for namespaces containing controllers developed for Stonesoup. For example, we would annotate the `gitops-service-argocd` namespace but not the `openshift-gitops` namespace.
 - `appstudio.redhat.com/namespacetype: "user-workspace-data"` for User workspaces where Applications, Components, and so on are stored

--- a/ADR/adr-0010-namespace-metadata
+++ b/ADR/adr-0010-namespace-metadata
@@ -13,6 +13,9 @@ Accepted
 
 ## Reviewers
 
+* Matous Jobanek
+* Ralph Bean
+
 ## Context
 
 We need metadata on our namespaces to make Stonesoup easier to operate and maintain. Standardizing namespace metadata will make it easier for us to search our logs and metrics across clusters. It will also allow us to enable logging for outgoing network traffic, one of our security requirements.

--- a/ADR/adr-0010-namespace-metadata
+++ b/ADR/adr-0010-namespace-metadata
@@ -15,6 +15,7 @@ Accepted
 
 * Matous Jobanek
 * Ralph Bean
+* Alexey Kazakov
 
 ## Context
 

--- a/ADR/adr-0010-namespace-metadata
+++ b/ADR/adr-0010-namespace-metadata
@@ -1,6 +1,6 @@
-# 1. Record architecture decisions
+# ADR-0010 Namespace Metadata
 
-Date: 2022-November-11
+Date: 2022-December-9
 
 ## Status
 

--- a/ADR/adr-0010-namespace-metadata
+++ b/ADR/adr-0010-namespace-metadata
@@ -21,22 +21,22 @@ We need metadata on our namespaces to make Stonesoup easier to operate and maint
 
 We will apply the following labels to Stonesoup namespaces, to make them easier to identify programmatically:
 
-- `stonesoup.redhat.com/namespacetype: "controller"` for namespaces containing controllers developed for Stonesoup. For example, we would annotate the `gitops-service-argocd` namespace but not the `openshift-gitops` namespace.
-- `stonesoup.redhat.com/namespacetype: "user-workspace-data"` for User workspaces where Applications, Components, and so on are stored
-- `stonesoup.redhat.com/namespacetype: "user-deployments"` for the namespaces where GitOps deploys applications for users
-- `stonesoup.redhat.com/namespacetype: "user-builds"` for the namespaces where the Pipeline Service manages users' PipelineRun resources
+- `appstudio.redhat.com/namespacetype: "controller"` for namespaces containing controllers developed for Stonesoup. For example, we would annotate the `gitops-service-argocd` namespace but not the `openshift-gitops` namespace.
+- `appstudio.redhat.com/namespacetype: "user-workspace-data"` for User workspaces where Applications, Components, and so on are stored
+- `appstudio.redhat.com/namespacetype: "user-deployments"` for the namespaces where GitOps deploys applications for users
+- `appstudio.redhat.com/namespacetype: "user-builds"` for the namespaces where the Pipeline Service manages users' PipelineRun resources
 
 The following labels are used for billing and telemetry. Values can be left blank if they are not defined yet:
 
-- `stonesoup.redhat.com/workspace_id: 12345678` a globally unique identifier for the workspace
-- `stonesoup.redhat.com/workspace_name: "test_workspace"` a name for the workspace (need not be unique)
-- `stonesoup.redhat.com/external_organization: 11868048` the Red Hat orgId
-- `stonesoup.redhat.com/product_variant: "Stonesoup"` identifier for the type of product (allows tracking multiple variants in the same metric)
-- `stonesoup.redhat.com/sku_account_support: "Standard"` Standard, Premium, or Self-Support. Must match the value from the SKU.
-- `stonesoup.redhat.com/sku_env_usage: "Production"` Development/Test, Production, or Disaster Recovery. Must match the value from the SKU
-- `stonesoup.redhat.com/billing_model: "marketplace"` must be set to marketplace to indicate this service instance is billed through marketplace. This allows you to mark some instances as billed via marketplace (and some as not billed through marketplace)
-- `stonesoup.redhat.com/billing_marketplace: "aws"` which marketplace is used for billing
-- `stonesoup.redhat.com/billing_marketplace_account: 123456789012` the customer account identifier (numeric AWS identifier). Necessary because a customer can have more than one AWS account.
+- `appstudio.redhat.com/workspace_id: 12345678` a globally unique identifier for the workspace
+- `appstudio.redhat.com/workspace_name: "test_workspace"` a name for the workspace (need not be unique)
+- `appstudio.redhat.com/external_organization: 11868048` the Red Hat orgId
+- `appstudio.redhat.com/product_variant: "Stonesoup"` identifier for the type of product (allows tracking multiple variants in the same metric)
+- `appstudio.redhat.com/sku_account_support: "Standard"` Standard, Premium, or Self-Support. Must match the value from the SKU.
+- `appstudio.redhat.com/sku_env_usage: "Production"` Development/Test, Production, or Disaster Recovery. Must match the value from the SKU
+- `appstudio.redhat.com/billing_model: "marketplace"` must be set to marketplace to indicate this service instance is billed through marketplace. This allows you to mark some instances as billed via marketplace (and some as not billed through marketplace)
+- `appstudio.redhat.com/billing_marketplace: "aws"` which marketplace is used for billing
+- `appstudio.redhat.com/billing_marketplace_account: 123456789012` the customer account identifier (numeric AWS identifier). Necessary because a customer can have more than one AWS account.
 
 ## Namespace annotations
 
@@ -48,4 +48,4 @@ metadata:
 
 ## Consequences
 
-We might have to migrate `stonesoup.redhat.com` to another product name in the future.
+We might have to migrate `appstudio.redhat.com` to another product name in the future, but it's the best option we have right now.

--- a/ADR/adr-0010-namespace-metadata
+++ b/ADR/adr-0010-namespace-metadata
@@ -34,7 +34,7 @@ The following labels are used for billing and telemetry. Values can be left blan
 
 - `appstudio.redhat.com/workspace_id: 12345678` a globally unique identifier for the workspace
 - `appstudio.redhat.com/workspace_name: "test_workspace"` a name for the workspace (need not be unique)
-- `appstudio.redhat.com/external_organization: 11868048` the Red Hat orgId
+- `appstudio.redhat.com/external_organization: 11868048` the Red Hat orgId of the user account that created the workspace
 - `appstudio.redhat.com/product_variant: "Stonesoup"` identifier for the type of product (allows tracking multiple variants in the same metric)
 - `appstudio.redhat.com/sku_account_support: "Standard"` Standard, Premium, or Self-Support. Must match the value from the SKU.
 - `appstudio.redhat.com/sku_env_usage: "Production"` Development/Test, Production, or Disaster Recovery. Must match the value from the SKU

--- a/book/index.md
+++ b/book/index.md
@@ -61,6 +61,10 @@ Each service is that makes up AppStudio and HACBS are further decomposed on thei
 - [Service Provider](../ref/service-provider.md)
 - [GitOps Service](../ref/gitops.md):
 
+### Naming Conventions
+
+- [Namespace Metadata](../ADR/adr-0010-namespace-metadata)
+
 ### Control Plane
 
 - [KCP](../ref/kcp.md)


### PR DESCRIPTION
The namespace labels are to help us in quickly searching logs across clusters and namespaces.
The metadata will help us meet this Red Hat requirement: SEC-NET-REQ-5 Monitor Outgoing Internet Traffic
Story: [ASC-186](https://issues.redhat.com/browse/ASC-186)