### PR TITLE
Build devsandbox APIs in our reference

### DIFF
--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -6,7 +6,7 @@ name: generate-api-docs
 on:
   workflow_dispatch:
   workflow_call:
-    
+
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Checkout docs repo 
+      - name: Checkout docs repo
         uses: actions/checkout@v3
-      
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout Application and Environment API
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
         with:
           repository: redhat-appstudio/service-provider-integration-operator
           path: crd-temp/service-provider
-      
+
       - name: Checkout GitOps
         uses: actions/checkout@v3
         with:
@@ -68,7 +68,7 @@ jobs:
           uri: 'https://github.com/elastic/crd-ref-docs/releases/download/v0.0.8/crd-ref-docs'
           name: 'crd-ref-docs'
           version: '0.0.8'
-      
+
       - name: Generate service provider API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/service-provider.md --renderer=markdown --source-path=crd-temp/service-provider/api/v1beta1
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Generate GitOps service API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/gitops.md --renderer=markdown --source-path=crd-temp/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1
-             
+
       - name: Generate Integration Service API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/integration-service.md --renderer=markdown --source-path=crd-temp/integration-service/api/v1alpha1/
 

--- a/.github/workflows/generate-api-docs.yml
+++ b/.github/workflows/generate-api-docs.yml
@@ -62,6 +62,12 @@ jobs:
           path: crd-temp/enterprise-contract-controller
           repository: hacbs-contract/enterprise-contract-controller
 
+      - name: Checkout DevSandbox API
+        uses: actions/checkout@v3
+        with:
+          path: crd-temp/devsandbox-api
+          repository: codeready-toolchain/api
+
       - name: Install crd-ref-docs
         uses: supplypike/setup-bin@v1
         with:
@@ -89,6 +95,9 @@ jobs:
 
       - name: Generate Enterprise Contract API docs
         run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/enterprise-contract.md --renderer=markdown --source-path=crd-temp/enterprise-contract-controller/api/v1alpha1/
+
+      - name: Generate devsandbox API docs
+        run: crd-ref-docs --log-level=ERROR --config=ref/config.yaml --output-path=ref/devsandbox.md --renderer=markdown --source-path=crd-temp/devsandbox-api/api/v1alpha1
 
       - name: Upload generated docs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
They're not user-facing APIs, but we do end up having to talk about
them amongst the Stone Soup teams. Include them in our reference
here so we can refer to them from ADRs and provide links to each
other in slack.
