### PR TITLE
SPI CR permission refinement

### DIFF
--- a/ADR/0011-roles-and-permissions.md
+++ b/ADR/0011-roles-and-permissions.md
@@ -51,7 +51,7 @@ We will use the built-in Kubernetes RBAC system for Stonesoup's role and permiss
 |               | Release Strategy        | appstudio.redhat.com      | *                                       | releases, releasestrategies, releaseplans
 |               | Release Admission Plan  | appstudio.redhat.com      | *                                       | releaseplanadmissions
 |               | *JVM Build Service*     | jvmbuildservice.io        | get, list, watch, create, update, patch | jbsconfigs, artifactbuilds
-|               | *Service Access*        | appstudio.redhat.com      | get, list, watch, create, update, patch | spiaccesstokenbindings, spiaccesschecks, spiaccesstokens, spifilecontentrequests
+|               | *Service Access*        | appstudio.redhat.com      | get, list, watch, create, update, patch | spiaccesstokenbindings, spiaccesschecks, spiaccesstokens, spifilecontentrequests, spiaccesstokendataupdates
 |               | *Configs*               |                           | get, list, watch                        | configmaps
 |               | *Secrets*               |                           |                                         | secrets
 |               | Add User                |
@@ -68,7 +68,7 @@ We will use the built-in Kubernetes RBAC system for Stonesoup's role and permiss
 |               | Release Strategy        | appstudio.redhat.com      | *                                       | releases, releasestrategies, releaseplans
 |               | Release Admission Plan  | appstudio.redhat.com      | *                                       | releaseplanadmissions
 |               | *JVM Build Service*     | jvmbuildservice.io        | *                                       | jbsconfigs, artifactbuilds
-|               | *Service Access*        | appstudio.redhat.com      | *                                       | spiaccesstokenbindings, spiaccesschecks, spiaccesstokens,spifilecontentrequests
+|               | *Service Access*        | appstudio.redhat.com      | *                                       | spiaccesstokenbindings, spiaccesschecks, spiaccesstokens,spifilecontentrequests, spiaccesstokendataupdates
 |               | *Configs*               |                           | *                                       | configmaps
 |               | *Secrets*               |                           | *                                       | secrets
 |               | Add User                |


### PR DESCRIPTION
That is a refinement of SPI CR permission. 
That is an internal object that is used to communicate between OAuth service and the operator. 
It is created on behalf of the user. But they never directly interact with it.
In the future, we are planning to get rid of it and use a different technique. 
More about this object https://issues.redhat.com/browse/SVPI-303.