### PR TITLE
Add GitOpsDeployment* resources to roles and permissions

### DIFF
--- a/ADR/0011-roles-and-permissions.md
+++ b/ADR/0011-roles-and-permissions.md
@@ -26,7 +26,7 @@ We will use the built-in Kubernetes RBAC system for AppStudio's role and permiss
 |               | Application & Component | appstudio.redhat.com      | get, list, watch                        | applications, components, componentdetectionqueries
 |               | Environment             | appstudio.redhat.com      | get, list, watch                        | promotionruns, snapshotenvironmentbindings, snapshots, environments
 |               | DeploymentTarget & DeploymentTargetClaim | appstudio.redhat.com      | get, list, watch       | deploymenttargets, deploymenttargetclaims
-|               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments
+|               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns
 |               | PipelineRun             | tekton.dev                | get, list, watch                        | pipelineruns
 |               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records
 |               | IntegrationTestScenario | appstudio.redhat.com      | get, list, watch                        | integrationtestscenarios
@@ -43,7 +43,7 @@ We will use the built-in Kubernetes RBAC system for AppStudio's role and permiss
 |               | Application & Component | appstudio.redhat.com      | get, list, watch, create, update, patch | applications, components, componentdetectionqueries
 |               | Environment             | appstudio.redhat.com      | get, list, watch                        | promotionruns, snapshotenvironmentbindings, snapshots, environments
 |               | DeploymentTarget & DeploymentTargetClaim | appstudio.redhat.com      | get, list, watch       | deploymenttargets, deploymenttargetclaims
-|               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments
+|               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns
 |               | PipelineRun             | tekton.dev                | get, list, watch                        | pipelineruns
 |               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records
 |               | IntegrationTestScenario | appstudio.redhat.com      | *                                       | integrationtestscenarios
@@ -60,7 +60,7 @@ We will use the built-in Kubernetes RBAC system for AppStudio's role and permiss
 |               | Application & Component | appstudio.redhat.com      | *                                       | applications, components, componentdetectionqueries
 |               | Environment             | appstudio.redhat.com      | *                                       | promotionruns, snapshotenvironmentbindings, snapshots, environments
 |               | DeploymentTarget & DeploymentTargetClaim | appstudio.redhat.com      | *                      | deploymenttargets, deploymenttargetclaims
-|               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments
+|               | *GitOps*                | managed-gitops.redhat.com | *                                       | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns
 |               | PipelineRun             | tekton.dev                | *                                       | pipelineruns
 |               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records
 |               | IntegrationTestScenario | appstudio.redhat.com      | *                                       | integrationtestscenarios


### PR DESCRIPTION
Add the other `GitOpsDeployment*` Resources to ADR-11

Corresponding Core PRs:
- https://github.com/codeready-toolchain/toolchain-e2e/pull/693
- https://github.com/codeready-toolchain/host-operator/pull/781