### PR TITLE
doc(STONEINTG-371): Document behavior for components with no image

### DIFF
--- a/book/integration-service.md
+++ b/book/integration-service.md
@@ -162,6 +162,7 @@ The Integration service needs secrets mounted so that the `Environment Provision
     - for each Component extract the `spec.containerImage`
 3. Create a Snapshot
     - Populate the `spec.components` list with the component name and the `spec.containerImage` with information from Step 1 and 2, replacing the container image for the built component with the one from the build PipelineRun
+    - If a component does not have a container image associated with it then the component will not be added to the snapshot
 4. Create PipelineRuns for each IntegrationTestScenario
     - Fetch the IntegrationTestScenario for the application/component to get the Tekton Bundle and Environment information
     - Assign annotations of


### PR DESCRIPTION
There is a race condition in the integration service when two component builds are triggered in close succession with one another.  Components whose builds have not yet finished are sometimes added to the ApplicationSnapshot tested by the integration service.  This can lead to undefined failures in the service.  This was resolved by checking each component being added to the snapshot and omitting components with no image.

This documentation change clarifies the behavior described above.