### PR TITLE
ADR-11: Remove write access to all GitOpsDeployment* resources, from all roles

### DIFF
--- a/ADR/0011-roles-and-permissions.md
+++ b/ADR/0011-roles-and-permissions.md
@@ -60,7 +60,7 @@ We will use the built-in Kubernetes RBAC system for AppStudio's role and permiss
 |               | Application & Component | appstudio.redhat.com      | *                                       | applications, components, componentdetectionqueries
 |               | Environment             | appstudio.redhat.com      | *                                       | promotionruns, snapshotenvironmentbindings, snapshots, environments
 |               | DeploymentTarget & DeploymentTargetClaim | appstudio.redhat.com      | *                      | deploymenttargets, deploymenttargetclaims
-|               | *GitOps*                | managed-gitops.redhat.com | *                                       | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns
+|               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns
 |               | PipelineRun             | tekton.dev                | *                                       | pipelineruns
 |               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records
 |               | IntegrationTestScenario | appstudio.redhat.com      | *                                       | integrationtestscenarios


### PR DESCRIPTION
For security purposes, only the GitOps Service controllers should be able to create/modify/delete the `GitOpsDeployment*` resources, at this time.

* Note this does not effect the Environment API (Snapshots, Environments, SnapshotEnvironmentBindings, etc).

#### Corresponding PRs:
- *Host-operator*: https://github.com/codeready-toolchain/host-operator/pull/793
- *Toolchain-e2e*: https://github.com/codeready-toolchain/toolchain-e2e/pull/712
