### PR TITLE
PLNSRVCE-1167: add logs resource to tekton results RBAC

### DIFF
--- a/ADR/0011-roles-and-permissions.md
+++ b/ADR/0011-roles-and-permissions.md
@@ -28,7 +28,7 @@ We will use the built-in Kubernetes RBAC system for AppStudio's role and permiss
 |               | DeploymentTarget & DeploymentTargetClaim | appstudio.redhat.com      | get, list, watch       | deploymenttargets, deploymenttargetclaims
 |               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns
 |               | PipelineRun             | tekton.dev                | get, list, watch                        | pipelineruns
-|               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records
+|               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records, logs
 |               | IntegrationTestScenario | appstudio.redhat.com      | get, list, watch                        | integrationtestscenarios
 |               | Enterprise contract     | appstudio.redhat.com      | get, list, watch                        | enterprisecontractpolicies
 |               | Release Strategy        | appstudio.redhat.com      | get, list, watch                        | releases, releasestrategies, releaseplans
@@ -45,7 +45,7 @@ We will use the built-in Kubernetes RBAC system for AppStudio's role and permiss
 |               | DeploymentTarget & DeploymentTargetClaim | appstudio.redhat.com      | get, list, watch       | deploymenttargets, deploymenttargetclaims
 |               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns
 |               | PipelineRun             | tekton.dev                | get, list, watch                        | pipelineruns
-|               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records
+|               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records, logs
 |               | IntegrationTestScenario | appstudio.redhat.com      | *                                       | integrationtestscenarios
 |               | Enterprise contract     | appstudio.redhat.com      | get, list, watch                        | enterprisecontractpolicies
 |               | Release Strategy        | appstudio.redhat.com      | *                                       | releases, releasestrategies, releaseplans
@@ -62,7 +62,7 @@ We will use the built-in Kubernetes RBAC system for AppStudio's role and permiss
 |               | DeploymentTarget & DeploymentTargetClaim | appstudio.redhat.com      | *                      | deploymenttargets, deploymenttargetclaims
 |               | *GitOps*                | managed-gitops.redhat.com | get, list, watch                        | gitopsdeployments, gitopsdeploymentmanagedenvironments, gitopsdeploymentrepositorycredentials, gitopsdeploymentsyncruns
 |               | PipelineRun             | tekton.dev                | *                                       | pipelineruns
-|               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records
+|               | Pipeline Results        | results.tekton.dev        | get, list                               | results, records, logs
 |               | IntegrationTestScenario | appstudio.redhat.com      | *                                       | integrationtestscenarios
 |               | Enterprise contract     | appstudio.redhat.com      | *                                       | enterprisecontractpolicies
 |               | Release Strategy        | appstudio.redhat.com      | *                                       | releases, releasestrategies, releaseplans


### PR DESCRIPTION
the upstream tekton results project and its REST API has evolved to the point where `logs` are now a separate resource, and RBAC needs to be adjusted for users to pass the SAR check when viewing logs

See the [TEP-0117](https://github.com/tektoncd/community/blob/main/teps/0117-tekton-results-logs.md) work from @sayan-biswas 

related PRs
https://github.com/codeready-toolchain/host-operator/pull/796
https://github.com/codeready-toolchain/toolchain-e2e/pull/716

/assign @sbose78 
/assign @gorkem 

@adambkaplan @alexeykazakov FYI
