### PR TITLE
fix: typo in ADR 6 Log Conventions

### DIFF
--- a/ADR/0006-log-conventions.md
+++ b/ADR/0006-log-conventions.md
@@ -219,7 +219,7 @@ func f() {
   },
   "additionalProperties": true,
   "required": ["ts", "level", "msg"],
-  "not" {
+  "not": {
     "required": [
       "namespace_name",
       "container_name",


### PR DESCRIPTION
Fixes a typo in ADR 6 Log Conventions JSON schema

https://github.com/redhat-appstudio/book/blob/2715251eb4da75778c9286644bdc89272ef4b7f8/ADR/0006-log-conventions.md?plain=1#L222