### PR TITLE
Fix: Broken links to SVGs

### DIFF
--- a/architecture-overview-slides.md
+++ b/architecture-overview-slides.md
@@ -18,10 +18,10 @@ A set of services that streamline, consolidate, connect, and secure the enterpri
 
 #### AppStudio System Context
 
-![System Context](./diagrams/appstudio-l1.drawio.svg)
+![System Context](appstudio-l1.drawio.svg)
 
 ---
 
 #### AppStudio Services
 
-![Data Plane](./diagrams/appstudio-l2.drawio.svg)
+![Data Plane](appstudio-l2.drawio.svg)


### PR DESCRIPTION
AppStudio Architecture Overview contain links to SVGs which were moved. This is caused the links to the SVGs to break and therefore the SVGs are not loaded.