### PR TITLE
Add o11y members to the OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,3 +21,6 @@ approvers:
 - deboer-tim
 - ksprinkl
 - scoheb
+- eisraeli
+- amisstea
+- bkorren


### PR DESCRIPTION
Added three representatives from the o11y team to the OWNERS file to speed-up the review and merging of observability-related ADRs and documents.