### PR TITLE
docs(STONEINTG-496): remove the link for unused tasks

### DIFF
--- a/tools/security-tools.MD
+++ b/tools/security-tools.MD
@@ -39,12 +39,8 @@ _Note: [clair-in-ci](https://quay.io/repository/redhat-appstudio/clair-in-ci) is
 ### SAST Tools
 
 **_gosec_** - https://github.com/securego/gosec
- 
-_Note: AppStudio uses gosec to perform static analysis on our Golang projects. A Tekton Task is available that can be used to run gosec in your own Pipelines [here](https://github.com/redhat-appstudio/build-definitions/blob/main/task/sast-go/)._
 
 **find-sec-bugs** - https://github.com/find-sec-bugs/find-sec-bugs
-
-_Note: AppStudio uses find-sec-bugs to perform static analysis on our Java builds. A Tekton Task is available that can be used to run find-sec-bugs on a Java application in your own Pipelines [here](https://github.com/redhat-appstudio/build-definitions/blob/main/task/sast-java-sec-check)._
 
 **synk** - https://github.com/snyk/cli
 


### PR DESCRIPTION
* Since sast-go and sast-java-sec-check are not used and are removed from
  build-definistion https://github.com/redhat-appstudio/build-definitions/pull/488,
  so let's remove the link of the tasks from security-tools doc.

Signed-off-by: Hongwei Liu <hongliu@redhat.com>