### PR TITLE
Clarify build service update trigger

### DIFF
--- a/ADR/0029-component-dependencies.md
+++ b/ADR/0029-component-dependencies.md
@@ -81,7 +81,7 @@ See also [RHTAP-371](https://issues.redhat.com/browse/RHTAP-371).
   * If this is the first time it has seen this **nudging** component updated in this way, it will file a new pull request on the **nudged** components supplying the pullspec and digest of the new **nudging** components, using the same branch name prefix as was used for the **nudging** component PR.
   * If a PR on that branch already exists, update that branch with an additional commit including the new **nudging** component digest.
 
-The [build-service] will also update the PR it filed (PR#2) when the PRs (PR#1) that previously triggered [build-service] to create the PR#2 are merged or have new commits pushed to them. The [build-service] may need to update the description of PR#2 and/or it may rebase PR#2 on the main branch. Need to figure out what we want here.
+The [build-service] will also update the PR it filed (PR#2) when it detects new PipelineRuns from the originating PRs (PR#1) that previously triggered [build-service] to create the PR#2, indicating that the originating PRs (PR#1) were merged or had new commits pushed to them. The [build-service] may need to update the description of PR#2 and/or it may rebase PR#2 on the main branch. Need to figure out what we want here.
 
 ### Integration-service and PR Groups
 


### PR DESCRIPTION
This came up in feature refinement. The expectation is not that build-service will need to grow a new webhook handler to listen to events directly from github. Instead, the expectation is to use PipelineRuns (created by PaC) as the signal indicating that something has happened on GitHub.