### PR TITLE
Update BuildPipelineSelector example to new syntax

### DIFF
--- a/book/build-service.md
+++ b/book/build-service.md
@@ -76,8 +76,14 @@ spec:
   selectors:
   - name: my-component
     pipelineRef:
-      bundle: quay.io/my-user/my-bundle:v1.0
-      name: my-bundle
+      resolver: bundles
+      params:
+      - name: bundle
+        value: quay.io/my-user/my-bundle:v1.0
+      - name: name
+        value: my-bundle
+      - name: kind
+        value: pipeline
     pipelineParams:
     - name: test
       value: fbc
@@ -87,27 +93,51 @@ spec:
       projectType: springboot
   - name: Label section
     pipelineRef:
-      bundle: quay.io/my-user/my-bundle:v1.0
-      name: labelled
+      resolver: bundles
+      params:
+      - name: bundle
+        value: quay.io/my-user/my-bundle:v1.0
+      - name: name
+        value: labelled
+      - name: kind
+        value: pipeline
     when:
       labels:
         mylabel: test
   - name: Docker build
     pipelineRef:
-      bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:3649b8ca452e7f97e016310fccdfb815e4c0aa7e
-      name: docker-build
+      resolver: bundles
+      params:
+      - name: bundle
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:3649b8ca452e7f97e016310fccdfb815e4c0aa7e
+      - name: name
+        value: docker-build
+      - name: kind
+        value: pipeline
     when:
       dockerfile: true
   - name: NodeJS
     pipelineRef:
-      bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-nodejs-builder:3649b8ca452e7f97e016310fccdfb815e4c0aa7e
-      name: nodejs-builder
+      resolver: bundles
+      params:
+      - name: bundle
+        value: quay.io/redhat-appstudio-tekton-catalog/pipeline-nodejs-builder:3649b8ca452e7f97e016310fccdfb815e4c0aa7e
+      - name: name
+        value: nodejs-builder
+      - name: kind
+        value: pipeline
     when:
       language: nodejs,node
   - name: Fallback
     pipelineRef:
-      bundle: quay.io/my-user/my-fallback:v1.0
-      name: fallback
+      resolver: bundles
+      params:
+      - name: bundle
+        value: quay.io/my-user/my-fallback:v1.0
+      - name: name
+        value: fallback
+      - name: kind
+        value: pipeline
 ```
 
 In the example the first selector will match only when the component CR name is `my-component` and it's defined in the devfile or detected with `language: java` and `projectType: springboot` if all requests are matching then PipelineRun is generated based on `pipelineRef` and pipelineRun parameters are set to pipelineParams. If any of `when` condition does not match then it's checking the next selector. The `Fallback` sector does not contain `when` so it will be processed in case previous selectors do not match.


### PR DESCRIPTION
The BuildPipelineSelector CRD includes a pipelineRef field defined as a Tekton PipelineRef. Previously, build-service used the Tekton v1beta1 APIs. The v1beta1.PielineRef [1] object supports specifying pipelines in two different ways:

1) name + bundle:
```
pipelineRef:
  name: mypipeline
  bundle: docker.io/myrepo/mycatalog:v1.0
```
2) resolver + params:
```
pipelineRef:
  resolver: bundles
  params:
  - name: kind
    value: pipeline
  - name: name
    value: mypipeline
  - name: bundle
    value: docker.io/myrepo/mycatalog:v1.0
```
Build-service used to support only the first style. While migrating to the Tekton v1 APIs, we added support for the second style.

For now, we maintain backwards compatibility with the first style, but are planning to drop it soon. The v1.PipelineRef [2] object supports only the second style.

Update the BuildPipelineSelector example to use the second style.

[1]: https://tekton.dev/docs/pipelines/pipeline-api/#tekton.dev/v1beta1.PipelineRef
[2]: https://tekton.dev/docs/pipelines/pipeline-api/#tekton.dev/v1.PipelineRef