### PR TITLE
doc: document changes to snapshot preparation for integration service

### DIFF
--- a/book/integration-service.md
+++ b/book/integration-service.md
@@ -210,19 +210,25 @@ The Integration service needs secrets mounted so that the `Environment Provision
 
 ### Image extraction details
 
-Integration service is getting specific information about the image that's being built by the RHTAP build pipeline by parsing the expected Tekton results for the pipeline. All of them are required to be present in order to correctly construct a Snapshot.
+Integration service is getting specific information about the image that's being built by the RHTAP build pipeline by parsing the expected Tekton results for the pipeline.
 
 <ins>Results are following:</ins>
- - IMAGE_URL
+ - IMAGE_URL *required*
     - Represents image repository where the built image was pushed. Used to construct the component image reference.
- - IMAGE_DIGEST
+ - IMAGE_DIGEST *required*
     - Digest of the image that was built. Used to construct the component image reference.
  - CHAINS-GIT_URL
-    - Git url of the source repository. Added to the source section of the component within the Snapshot.
+    - Git url of the target repository.
  - CHAINS-GIT_COMMIT
-    - The precise commit SHA that was fetched by git-clone task. Added to the source section of the component within the Snapshot.
+    - The precise commit SHA that was fetched by git-clone task.
 
 >All those results contributes to a snapshot preparation for a pipelinerun
+
+<ins>Parameters are following:</ins>
+- git-url *required*
+    - Git url of the source repository.  Added to the source section of the component within the snapshot
+- revision *required*
+    - The precise commit SHA that was fetched by git-clone task. Added to the source section of the component within the Snapshot.
 
 
 ## Appendix


### PR DESCRIPTION
The integration service previously used CHAINS-GIT_URL and CHAINS-GIT_COMMIT to test PR changes. However, CHAINS-GIT_URL points to the target repository, not the source repository.  In order to fix this the integration service switched to using `params.git-url` and `params.revision`.  This change documents those code changes.